### PR TITLE
Version 0.3.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Herb"
 uuid = "c09c6b7f-4f63-49de-90d9-97a3563c0f4a"
 authors = ["Jaap de Jong <jaapdejong15@gmail.com>", "Tilman Hinnerichs <t.r.hinnerichs@tudelft.nl>", "Sebastijan Dumancic <s.dumancic@tudelft.nl>"]
-version = "0.2.0"
+version = "0.3.0"
 
 [deps]
 HerbConstraints = "1fa96474-3206-4513-b4fa-23913f296dfc"
@@ -13,11 +13,11 @@ HerbSpecification = "6d54aada-062f-46d8-85cf-a1ceaf058a06"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 
 [compat]
-HerbConstraints = "^0.1.1"
-HerbCore = "^0.2.0"
-HerbInterpret = "^0.1.2"
+HerbConstraints = "^0.2.0"
+HerbCore = "^0.3.0"
 HerbGrammar = "^0.2.1"
-HerbSearch = "^0.2.0"
+HerbInterpret = "^0.1.3"
+HerbSearch = "^0.3.0"
 HerbSpecification = "^0.1.0"
 julia = "^1.8"
 


### PR DESCRIPTION
Numerous breaking changes across `Herb*.jl` packages, prompting a version bump (`v0.2.0` -> `v0.3.0`) of this umbrella repo.

Waiting on (at minimum):

- https://github.com/Herb-AI/HerbSearch.jl/pull/82
- https://github.com/Herb-AI/HerbConstraints.jl/pull/33
- https://github.com/Herb-AI/HerbInterpret.jl/pull/23
- https://github.com/Herb-AI/HerbCore.jl/pull/17

Before this is ready to be merged.