### PR TITLE
Update `Herb*` packages

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -13,11 +13,11 @@ HerbSpecification = "6d54aada-062f-46d8-85cf-a1ceaf058a06"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 
 [compat]
-HerbConstraints = "^0.1.1"
-HerbCore = "^0.2.0"
+HerbConstraints = "^0.2.0"
+HerbCore = "^0.3.0"
+HerbGrammar = "^0.3.0"
 HerbInterpret = "^0.1.2"
-HerbGrammar = "^0.2.1"
-HerbSearch = "^0.2.0"
+HerbSearch = "^0.3.0"
 HerbSpecification = "^0.1.0"
 julia = "^1.8"
 


### PR DESCRIPTION
CI will fail until `HerbSearch` v0.3 is published.