### PR TITLE
Update contributors.yml

### DIFF
--- a/.github/workflows/contributors.yml
+++ b/.github/workflows/contributors.yml
@@ -37,12 +37,12 @@ jobs:
           ORGANIZATION: Herb-AI
           SPONSOR_INFO: "true"
           LINK_TO_PROFILE: "true"
+
+      - name: Check out repository code
+        uses: actions/checkout@v4
           
       - name: Add and commit CONTRIBUTORS.md
         uses: EndBug/add-and-commit@v9 
         with:
-          author_name: IssaHanou
-          author_email: i.k.hanou@tudelft.nl
           message: "Monthly contributors report"
           default_author: github_actor
-          fetch: false  


### PR DESCRIPTION
- As long as we have the bit with `default_author: github_actor`, the commit will be labeled as coming directly from GitHub Actions rather than from one of us.

- I believe we might need to check out the repo in the action before adding and committing, but removing `fetch: false` might do the same. 