### PR TITLE
Update contributors action

### DIFF
--- a/.github/workflows/contributors.yml
+++ b/.github/workflows/contributors.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v4
           
       - name: Run contributor action
-        uses: reubenj/contributors@v1.4.4
+        uses: github/contributors@v1.5.5
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           START_DATE: ""


### PR DESCRIPTION
The contributor action has been failing for some months now. It was using my fork of the action, but I think the original repo has the fixes we were waiting on now. I've bumped the version and switched back to `github`'s repo.