### PR TITLE
Remove reference of `SymbolTable` constructor

### DIFF
--- a/docs/src/tutorials/basic_getting_started.jl
+++ b/docs/src/tutorials/basic_getting_started.jl
@@ -57,7 +57,7 @@ solution, flag = synth(problem, iterator)
 md"
 There are various ways to adapt the search technique to your needs. Please have a look at the [`synth`](@ref) documentation.
 
-Eventually, we want to test our solution on some other inputs using `HerbInterpret`. We transform our grammar `g` to a Julia expression with `Symboltable(g)`, add our solution and the input, assigning the value `6` to the variable `x`.
+Eventually, we want to test our solution on some other inputs using `HerbInterpret`. We transform our grammar `g` to a Julia expression with `grammar2symboltable(g)`, add our solution and the input, assigning the value `6` to the variable `x`.
 "
 
 # ╔═╡ fb3e47bf-03f1-4eda-85ff-1897751c1d00


### PR DESCRIPTION
I missed this in-text reference to the `SymbolTable` constructor when reviewing #134.