### PR TITLE
Update Julia version mentioned in install.md

### DIFF
--- a/docs/src/install.md
+++ b/docs/src/install.md
@@ -1,6 +1,6 @@
 # Installation Guide
 
-Before installing Herb.jl, ensure that you have a running Julia distribution installed (Julia 1.7 or later was tested). 
+Before installing Herb.jl, ensure that you have a running Julia distribution installed (Julia 1.10 or later). 
 For information on installing Julia, getting to know it, and setting up an IDE, see [Modern Julia Workflows](https://modernjuliaworkflows.org/writing/)
 
 Thanks to Julia's package management, installing Herb.jl is very straightforward. 


### PR DESCRIPTION
I missed this in the review of #194. Just updating the minimum Julia version mentioned on the install page.

I double-checked that this is the only mention of the Julia version in the docs.