### PR TITLE
fix: update OSPO action references to canonical org path

### DIFF
--- a/.github/workflows/contributors.yml
+++ b/.github/workflows/contributors.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v4
           
       - name: Run contributor action
-        uses: github/contributors@v1.5.5
+        uses: github-community-projects/contributors@v1.5.5
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           START_DATE: ""


### PR DESCRIPTION
Updates GitHub Actions workflow references from the legacy `github/` org path to the canonical `github-community-projects/` path.

The following OSPO actions have been transferred to the `github-community-projects` organization:

| Legacy path | Canonical path |
|---|---|
| `github/contributors` | `github-community-projects/contributors` |

While GitHub's repo redirect ensures the old paths still work today, updating to the canonical path avoids depending on the redirect and ensures long-term stability.

**No functional changes** - the same action versions are referenced.
